### PR TITLE
Harness engineering: lint hook, ADR compliance reviewer, and architecture decisions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,12 @@
             "type": "command",
             "command": "jq -r '.tool_input.file_path // empty' | { read -r f; echo \"$f\" | grep -qE '\\.py$' && (uv run ruff check --fix \"$f\"; uv run ruff format \"$f\") || true; }",
             "statusMessage": "Linting..."
+          },
+          {
+            "type": "agent",
+            "prompt": "You are an independent ADR compliance reviewer with no knowledge of the current coding session. Tool input: $ARGUMENTS. Step 1: parse the JSON to extract tool_input.file_path. Step 2: if the path does not contain 'dnd_dm_agent/' or '.claude/skills/', output 'Not in scope.' and stop immediately. Step 3: use Read to read the modified file. Step 4: use Glob to list all files in docs/adr/, then Read each one. Step 5: check whether the file content or patterns violate any architectural decision — pay particular attention to the Constraint sections. Step 6: output either a list of specific violations with file:line references, or 'No ADR violations found.'",
+            "statusMessage": "Checking ADR compliance...",
+            "timeout": 60
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // empty' | { read -r f; echo \"$f\" | grep -qE '\\.py$' && (uv run ruff check --fix \"$f\"; uv run ruff format \"$f\") || true; }",
+            "statusMessage": "Linting..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,17 @@ uv run ruff format .
 
 
 
+## Architecture Decisions
+
+Key decisions are documented in `docs/adr/`. Read these before changing core patterns:
+
+- [ADR-001](docs/adr/001-minimal-mcp-tools.md) — Only 2 custom MCP tools; everything else via skills + built-in tools
+- [ADR-002](docs/adr/002-markdown-state-persistence.md) — Game state persisted as `.md` files, not a database
+- [ADR-003](docs/adr/003-skill-based-capabilities.md) — Domain logic lives in `.claude/skills/`, not Python or system prompt
+- [ADR-004](docs/adr/004-campaign-template-copy-on-create.md) — Campaign instances are full copies of templates, not references
+- [ADR-005](docs/adr/005-dm-first-async-bookkeeping.md) — DM responds first; bookkeeping runs async after
+- [ADR-006](docs/adr/006-isolated-bookkeeping-subagent.md) — Bookkeeping is an isolated subagent with fresh context and `bypassPermissions`
+
 ## Code Style
 
 - Python 3.13

--- a/dnd_dm_agent/claude_agent.py
+++ b/dnd_dm_agent/claude_agent.py
@@ -8,25 +8,24 @@ from pathlib import Path
 from typing import Any, AsyncIterator
 
 from claude_agent_sdk import (
-    query,
+    AssistantMessage,
     ClaudeAgentOptions,
     ClaudeSDKClient,
-    AssistantMessage,
     TextBlock,
     ToolUseBlock,
-    tool,
     create_sdk_mcp_server,
+    query,
+    tool,
 )
 
-from .logging_config import logger, dm_logger, bookkeeping_logger
+from .logging_config import bookkeeping_logger, dm_logger, logger
 
 # Project root directory (for skills and file operations)
 PROJECT_ROOT = str(Path(__file__).parent.parent.resolve())
 
 # Import domain logic from existing tools
-from .tools.utility_tools import roll_dice as _roll_dice
 from .tools.campaign_instance_tools import create_campaign_instance as _create_campaign_instance
-
+from .tools.utility_tools import roll_dice as _roll_dice
 
 # =============================================================================
 # Custom Tools

--- a/dnd_dm_agent/tools/utility_tools.py
+++ b/dnd_dm_agent/tools/utility_tools.py
@@ -2,8 +2,7 @@
 
 import random
 import re
-from typing import Dict, Any
-
+from typing import Any, Dict
 
 
 def parse_dice_notation(notation: str) -> tuple[int, int, int]:

--- a/docs/adr/001-minimal-mcp-tools.md
+++ b/docs/adr/001-minimal-mcp-tools.md
@@ -1,0 +1,20 @@
+# ADR-001: Minimal Custom MCP Tools
+
+## Status
+Accepted
+
+## Context
+Claude Agent SDK supports custom tools via MCP servers. It would be natural to build custom tools for every domain operation: updating character HP, advancing campaign beats, looking up spells, managing inventory, etc.
+
+## Decision
+Expose only 2 custom MCP tools:
+- `roll_dice` — dice mechanics require deterministic execution that the model cannot do reliably
+- `create_campaign_instance` — filesystem scaffolding that requires atomic multi-file creation
+
+Everything else (character CRUD, campaign state, D&D knowledge lookups, DM guidance) is handled via skills + built-in tools (Read, Write, Edit, Glob, Grep).
+
+## Consequences
+- **New capabilities go in skills, not tools.** Adding a skill is a markdown edit; adding a tool requires Python code, MCP server registration, and `allowed_tools` updates.
+- **No custom tool for character updates.** The character-management skill defines patterns for using Write/Edit safely — this is intentional, not an omission.
+- **Tool surface area stays minimal.** Fewer tools = simpler agent, less hallucination on tool selection, easier to reason about what the agent can do.
+- **Constraint:** Anything requiring guaranteed atomic execution or external side effects (dice randomness, filesystem scaffolding) is the right candidate for a real tool. Everything else is not.

--- a/docs/adr/002-markdown-state-persistence.md
+++ b/docs/adr/002-markdown-state-persistence.md
@@ -1,0 +1,27 @@
+# ADR-002: Markdown Files as State Persistence
+
+## Status
+Accepted
+
+## Context
+Game state (characters, campaign progress, session logs) needs to persist across turns and sessions. Common alternatives include SQLite, JSON with schemas, or in-memory state serialized to disk.
+
+## Decision
+All game state is stored as `.md` files in a structured directory layout:
+
+```
+campaigns/
+  [instance]/
+    characters/[name].md     # character sheets
+    campaign_progress.md     # current Act/Beat
+    campaign_log.md          # session history
+```
+
+Campaign story content (Acts, Beats, NPCs, locations) is also authored in markdown under `campaigns/available_campaigns/[template]/`.
+
+## Consequences
+- **Human-readable and git-diffable.** Players and DMs can inspect, edit, and version-control game state without tooling.
+- **No schema migrations.** Adding a new field to a character sheet is a markdown edit, not a database migration.
+- **Built-in tools work natively.** Read/Write/Edit/Grep operate directly on these files — no adapter layer needed.
+- **No ACID guarantees.** Concurrent writes (e.g., if bookkeeping and DM agent both write simultaneously) could corrupt state. This is acceptable in a single-session, single-user context.
+- **Constraint:** Do not move state into a database or structured JSON to "improve" it. The markdown format is load-bearing — it's what makes the built-in tool ecosystem work without custom persistence tooling.

--- a/docs/adr/003-skill-based-capabilities.md
+++ b/docs/adr/003-skill-based-capabilities.md
@@ -1,0 +1,24 @@
+# ADR-003: Skill-Based Distributed Logic
+
+## Status
+Accepted
+
+## Context
+Domain logic (D&D rules, character templates, campaign structure, DM techniques) needs to be accessible to the agent. Options include: embedding it in the system prompt, building it into Python tools, storing it in a vector database (RAG), or using the Claude Code skills system.
+
+## Decision
+All domain knowledge and capability patterns are factored into `.claude/skills/`:
+
+- `dnd-knowledge-store/` — D&D 5e rules, spells, monsters, class features
+- `character-management/` — character templates, edit patterns, validation rules
+- `campaign-guide/` — campaign loading, Acts/Beats tracking, post-turn bookkeeping checklist
+- `dnd-dm/` — DM narration techniques, pacing, improvisation guidance
+
+Skills are loaded on demand via the `Skill` tool and declare their own `allowed_tools`.
+
+## Consequences
+- **Adding knowledge requires no code changes.** New monsters, spells, or DM guidance is a markdown edit to a skill file.
+- **Skills are independently testable.** Each skill can be invoked in isolation without running the full agent.
+- **No RAG infrastructure.** The skills system avoids the complexity of embedding pipelines, vector stores, and retrieval tuning. Skills are loaded in full when invoked.
+- **Skills compose with built-in tools.** The character-management skill uses Write/Edit directly — no custom tool wrapper needed.
+- **Constraint:** Do not move skill content into the system prompt (bloats every conversation) or into Python (breaks the no-code-for-knowledge principle). If a capability can be expressed as a skill, it should be.

--- a/docs/adr/004-campaign-template-copy-on-create.md
+++ b/docs/adr/004-campaign-template-copy-on-create.md
@@ -1,0 +1,22 @@
+# ADR-004: Campaign Instances as Full Copies of Templates
+
+## Status
+Accepted
+
+## Context
+Campaigns have a template (story skeleton with Acts, Beats, NPCs, locations) and runtime instances (active playthroughs). The relationship between template and instance could be handled via references/symlinks (instance reads from template at runtime) or full copies (instance gets its own files at creation).
+
+## Decision
+`create_campaign_instance` copies the entire template directory to `campaigns/[instance]/`. Instances are fully independent from the moment of creation.
+
+Campaign story content follows an Acts/Beats structure:
+- **Acts** are major story phases
+- **Beats** are scene-level milestones with explicit accomplishment conditions
+- Progress is tracked in `campaign_progress.md` against this structure
+
+## Consequences
+- **Instances can diverge freely.** NPCs can be killed, locations can change, story branches can be added — none of this affects the template or other instances.
+- **Instances are archivable.** A completed campaign is a self-contained directory with full history in git.
+- **No runtime template dependency.** The agent never needs to read from `available_campaigns/` during active play.
+- **Beats provide pacing structure.** Clear accomplishment conditions (e.g., "solve the rat problem") tell the DM when to advance the story, preventing both railroading and aimless drift.
+- **Constraint:** Do not make instances reference template files at runtime. The copy-on-create model is intentional — modifying a template should never affect an active instance.

--- a/docs/adr/005-dm-first-async-bookkeeping.md
+++ b/docs/adr/005-dm-first-async-bookkeeping.md
@@ -1,0 +1,21 @@
+# ADR-005: DM Responds First, Bookkeeping Runs After
+
+## Status
+Accepted
+
+## Context
+Each player turn involves two concerns: (1) the DM narrating a response and (2) updating game state (character HP, spell slots, campaign progress, session log). These can be ordered as DM-first or bookkeeping-first, or run simultaneously.
+
+The frontend uses a WebSocket per session (session ID generated on client, stored in sessionStorage) with one persistent `ClaudeSDKClient` per session to stream DM responses and tool events in real time.
+
+## Decision
+The DM agent responds to the player first. Once the DM response is complete, a separate bookkeeping subagent runs asynchronously on the same turn's context (player message + DM response).
+
+The player sees the DM narration immediately. State updates happen in the background.
+
+## Consequences
+- **Responsive UX.** The player is never blocked waiting for bookkeeping to complete.
+- **Eventual consistency.** State files reflect the *previous* turn's outcome, not the current one, until bookkeeping finishes. This is acceptable — the DM agent has the full conversation context and doesn't need persisted state to narrate correctly.
+- **Bookkeeping has full context.** The handoff to the bookkeeping subagent includes both the player message and DM response, so nothing is lost.
+- **WebSocket streaming aligns with this model.** Tool events (dice rolls, character updates) stream to the frontend as they happen, giving the player visibility into background state changes.
+- **Constraint:** Do not block DM narration on bookkeeping completion. Do not make bookkeeping run before the DM responds. The ordering is intentional for UX reasons.

--- a/docs/adr/006-isolated-bookkeeping-subagent.md
+++ b/docs/adr/006-isolated-bookkeeping-subagent.md
@@ -1,0 +1,23 @@
+# ADR-006: Bookkeeping as an Isolated Subagent with Fresh Context
+
+## Status
+Accepted
+
+## Context
+State bookkeeping (updating character sheets, advancing campaign beats, writing session logs) could be handled by the main DM agent as part of its response, or by a persistent subagent that accumulates context, or by a lightweight subagent with fresh context each turn.
+
+## Decision
+Bookkeeping runs as a separate `ClaudeSDKClient` instance with:
+- **Fresh context per turn** — no conversation history carried over from previous turns
+- **`bypassPermissions` mode** — runs silently without prompting for file edit approvals
+- **Restricted tool set** — only `Skill`, `Read`, `Write`, `Edit`, `Glob` (no dice, no campaign creation)
+- **Domain logic delegated to skills** — the bookkeeping system prompt defers to `campaign-guide` skill for the post-turn checklist
+
+The main DM agent uses `acceptEdits` permission mode and never uses `bypassPermissions`.
+
+## Consequences
+- **Clean separation of concerns.** Narration and bookkeeping are distinct responsibilities with distinct agents, prompts, and permissions.
+- **Fresh context prevents drift.** The bookkeeping agent cannot be confused by earlier turns' narration accumulating in its context window.
+- **`bypassPermissions` is scoped to bookkeeping only.** This is intentional — silent file writes are correct for bookkeeping, but would be unsafe for the interactive DM agent.
+- **Checklist-driven.** Bookkeeping correctness is defined in the campaign-guide skill (the post-turn checklist), not in Python. Updating what gets tracked requires editing the skill, not the agent code.
+- **Constraint:** Do not give the bookkeeping agent accumulated conversation history. Do not apply `bypassPermissions` to the main DM agent. Do not move the bookkeeping checklist logic into Python.


### PR DESCRIPTION
## Summary

- **6 Architecture Decision Records** (`docs/adr/`) documenting key design choices with explicit Constraint sections — prevents accidental reversal of intentional decisions
- **Lint hook** (`settings.json`) — runs `ruff check --fix` + `ruff format` automatically after every Python file write
- **ADR compliance reviewer hook** — independent agent (fresh context, no session state) checks modified files in `dnd_dm_agent/` and `.claude/skills/` against the ADRs on every write
- **CLAUDE.md updated** with ADR index and architecture decision references

## Motivation

Harness engineering for the meta-level: making Claude Code more reliable when writing code for this project. The three main failure modes addressed:
- Writing bad code → lint hook
- Violating architecture → ADR compliance reviewer
- Missing context → CLAUDE.md + ADRs with Constraint sections

## Test Plan

- [ ] Verify lint hook fires on Python file edit (ruff output visible in spinner)
- [ ] Verify ADR reviewer fires on `dnd_dm_agent/*.py` edit and skips irrelevant files
- [ ] Verify ADR reviewer reports violations for code that breaks a constraint (e.g. adding a 3rd MCP tool)
- [ ] Confirm `uv run pytest tests/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)