### PR TITLE
Add agent harness: scenario evals, ADR decisions, and eval regression gate

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,7 +11,7 @@
           },
           {
             "type": "agent",
-            "prompt": "You are an independent ADR compliance reviewer with no knowledge of the current coding session. Tool input: $ARGUMENTS. Step 1: parse the JSON to extract tool_input.file_path. Step 2: if the path does not contain 'dnd_dm_agent/' or '.claude/skills/', output 'Not in scope.' and stop immediately. Step 3: use Read to read the modified file. Step 4: use Glob to list all files in docs/adr/, then Read each one. Step 5: check whether the file content or patterns violate any architectural decision — pay particular attention to the Constraint sections. Step 6: output either a list of specific violations with file:line references, or 'No ADR violations found.'",
+            "prompt": "You are an independent ADR compliance reviewer with no knowledge of the current coding session. Tool input: $ARGUMENTS. Step 1: parse the JSON to extract tool_input.file_path. Step 2: if the path does not contain 'dnd_dm_agent/' or '.claude/skills/', output 'Not in scope.' and stop immediately. Step 3: use Read to read the modified file. Step 4: use Glob to list all files in docs/adr/, then Read each one. Step 5: check whether the change violates any architectural decision OR triggers any required follow-up action stated in an ADR — pay particular attention to Constraint sections and any conditional requirements (e.g. 'any edit to X requires Y'). Step 6: output either a list of specific violations or required follow-up actions with ADR references and file:line details, or 'No ADR violations found.'",
             "statusMessage": "Checking ADR compliance...",
             "timeout": 60
           }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,27 @@ Key decisions are documented in `docs/adr/`. Read these before changing core pat
 - [ADR-005](docs/adr/005-dm-first-async-bookkeeping.md) — DM responds first; bookkeeping runs async after
 - [ADR-006](docs/adr/006-isolated-bookkeeping-subagent.md) — Bookkeeping is an isolated subagent with fresh context and `bypassPermissions`
 
+### Agent Harness (`docs/adr/agent-harness/`)
+
+Decisions about the harness layer that validates and guards the D&D agent's runtime behaviour:
+
+- [ADR-007](docs/adr/agent-harness/007-character-data-integrity-validator.md) — Rejected: bounds-check validator not worth the complexity; scenario evals cover the real failure mode
+- [ADR-008](docs/adr/agent-harness/008-bookkeeping-scenario-eval-suite.md) — Fixture-based integration tests assert correct post-turn state from `run_bookkeeping_subagent` directly
+- [ADR-009](docs/adr/agent-harness/009-bookkeeping-silence-check.md) — Rejected: post-hoc text-length check adds noise without action; evals cover the real failure mode
+- [ADR-010](docs/adr/agent-harness/010-eval-regression-gate.md) — Eval suite must pass before merging changes to `campaign-guide` skill or bookkeeping pipeline; enforced via ADR compliance reviewer hook
+
+## Eval Regression Gate
+
+**Before merging changes to either of these, run the bookkeeping eval suite and ensure all 4 pass:**
+- `.claude/skills/campaign-guide/` (any file)
+- `run_bookkeeping_subagent` or `get_bookkeeping_options` in `dnd_dm_agent/claude_agent.py`
+
+```bash
+uv run pytest tests/integration/test_bookkeeping_evals.py -v
+```
+
+See [ADR-010](docs/adr/agent-harness/010-eval-regression-gate.md) for rationale.
+
 ## Code Style
 
 - Python 3.13

--- a/docs/adr/agent-harness/007-character-data-integrity-validator.md
+++ b/docs/adr/agent-harness/007-character-data-integrity-validator.md
@@ -1,0 +1,29 @@
+# ADR-007: Character Data Integrity Validator
+
+## Status
+Rejected
+
+## Context
+The bookkeeping subagent writes to character sheets and campaign progress files using unstructured markdown edits. Because it runs with `bypassPermissions` and fresh context each turn (ADR-006), there is no review step and no structural awareness — it knows what to write from the campaign-guide skill, but nothing prevents it from writing `HP: 15/12` or `Used: 3 / Total: 2`.
+
+Two file types carry numeric invariants that can be silently violated:
+
+- **Character files** (`campaigns/*/characters/*.md`): HP stored as `current / max` in a markdown table; spell slots stored as `total | used | remaining` per level
+- **Campaign progress** (`campaigns/*/campaign_progress.md`): HP mirrored as `HP: current/max` inline
+
+Violations compound across turns — a corrupted HP value in one turn is the starting point for the next.
+
+## Decision
+Not implemented.
+
+The invariants under consideration (`current ≤ max` for HP, `used ≤ total` for spell slots) are small-number arithmetic on values that rarely exceed 20. The bookkeeping agent, guided by a structured skill checklist, handles this reliably. The added complexity of a parser, hook, and blocking logic is not justified by the actual failure rate.
+
+More importantly, bounds checking catches the wrong failure mode. A validator confirming `3 ≤ 12` gives false confidence — it does not catch the more likely error where the agent applies damage to a stale HP value it misread, producing an internally valid but incorrect result (e.g. `6/12` written when it should be `9/12`). That class of error requires behavioural testing, not structural validation.
+
+The higher-value harness investment is a scenario eval suite (ADR-008): fixture-based integration tests that assert the *correct* value was written after a known event, not merely a valid one.
+
+## Consequences
+- **No validator module added.** The codebase stays simpler; no new hook, no markdown parser.
+- **Arithmetic correctness is covered by the scenario eval suite.** A test that starts at known HP and asserts the right post-damage value subsumes what a bounds check would have caught.
+- **Structural corruption (agent edits wrong table cell) remains undetected at write time.** Accepted — this failure mode is rare and immediately obvious in play.
+- **Constraint:** Do not add a bounds-check validator as a substitute for behavioural tests. If numeric drift becomes a real observed problem in practice, revisit with a focused eval test rather than a structural hook.

--- a/docs/adr/agent-harness/008-bookkeeping-scenario-eval-suite.md
+++ b/docs/adr/agent-harness/008-bookkeeping-scenario-eval-suite.md
@@ -1,0 +1,78 @@
+# ADR-008: Bookkeeping Scenario Eval Suite
+
+## Status
+Accepted
+
+## Context
+The bookkeeping subagent (ADR-006) runs with fresh context and `bypassPermissions` after every DM turn. It is guided by a skill checklist but there are no automated checks that it applied the right state transition — only that it ran without error.
+
+The failure mode that matters is not structural invalidity (ADR-007 addressed this and rejected a bounds checker) but correctness: did the agent write the *right* value? A bookkeeping agent that reads a stale HP, applies correct arithmetic, and writes a valid but wrong result will silently corrupt game state across turns.
+
+The existing integration test (`test_character_management_create_and_update_wizard`) exercises the main DM agent doing character edits inline. It does not test the bookkeeping subagent in isolation, nor does it test campaign progress tracking or beat advancement.
+
+## Decision
+A scenario eval suite in `tests/integration/` exercises `run_bookkeeping_subagent` directly with known fixture state and synthetic DM exchanges, then asserts the correct post-turn file state.
+
+**Test structure per scenario:**
+1. Copy fixture files to a temporary campaign directory
+2. Call `run_bookkeeping_subagent(user_msg, dm_response, campaign, character)` directly
+3. Read the resulting character/campaign files
+4. Assert specific field values (not just structural validity)
+5. Clean up the temporary directory
+
+**Fixture files** live in `tests/fixtures/` as minimal but valid markdown character sheets and campaign progress files with known, controlled starting values. Fixtures are not copies of live campaign files — they are purpose-built for specific scenarios.
+
+**Scenarios to cover:**
+
+| Scenario | Starting state | Synthetic exchange | Assertion |
+|----------|---------------|-------------------|-----------|
+| HP damage | `HP: 10 / 12` | "Thork takes 3 damage" | character file contains `7 / 12` |
+| HP healing | `HP: 5 / 12` | "Thork drinks a healing potion, regains 4 HP" | character file contains `9 / 12` |
+| Spell slot use | `1st: total 2, used 0` | "Sapphire casts Magic Missile (1st level)" | spell slot used count is 1 |
+| Beat advancement | Beat 1.1 in progress | "Party solved the rat problem" | `campaign_progress.md` shows Beat 1.2 or Act 1 complete |
+
+**What evals do NOT assert:**
+- Exact wording of the bookkeeping agent's output (it should produce no narration, but the test does not parse its text)
+- Order of tool calls
+- DM narration quality
+
+These tests require `ANTHROPIC_API_KEY` and live in `tests/integration/` alongside the existing agent tests.
+
+**Estimated runtime per scenario:**
+
+Each scenario drives one full bookkeeping agent turn. The agent typically makes 4–6 tool calls: load the campaign-guide skill, read the character file, read `campaign_progress.md`, then one or two edits. At Sonnet-class latency (~2–4 s per API round-trip), a single scenario takes roughly **20–40 seconds**. The beat advancement scenario may take longer (~45–60 s) because it involves more file reads and potentially a more complex skill interaction.
+
+| Scenario | Expected tool calls | Estimated time |
+|----------|-------------------|----------------|
+| HP damage | 4–5 | ~20–35 s |
+| HP healing | 4–5 | ~20–35 s |
+| Spell slot use | 5–6 | ~25–40 s |
+| Beat advancement | 6–8 | ~40–60 s |
+| **Full suite (sequential)** | | **~2–3 min** |
+
+Scenarios are independent and can run in parallel (`pytest-asyncio` with `asyncio_mode = "auto"`) to bring wall-clock time down to the slowest single scenario (~45–60 s). API rate limits are unlikely to be a constraint at this scale.
+
+These estimates assume no cold-start delay beyond normal SDK initialisation. If the campaign-guide skill is large, the first Skill tool call may take longer on the first run of a session.
+
+**Estimated cost per scenario:**
+
+Token accumulation is dominated by the campaign-guide skill (~4,000 tokens) re-appearing in every subsequent call's context. Output tokens are small — the agent produces mostly tool call parameters, not prose. Based on the current skill and fixture file sizes:
+
+| Scenario | Est. input tokens | Est. output tokens | Est. cost (Sonnet) |
+|----------|------------------|-------------------|-------------------|
+| HP damage | ~20,000 | ~350 | ~$0.06 |
+| HP healing | ~20,000 | ~350 | ~$0.06 |
+| Spell slot use | ~23,000 | ~400 | ~$0.07 |
+| Beat advancement | ~37,000 | ~500 | ~$0.11 |
+| **Full suite** | | | **~$0.30** |
+
+At roughly $0.30 per full suite run, cost is not a material constraint. Running the suite weekly during active development costs ~$1.50/month. Running it on every PR that touches the campaign-guide skill or bookkeeping pipeline adds ~$0.30 per PR.
+
+These estimates assume Sonnet-class pricing (~$3/MTok input, ~$15/MTok output) and will shift if the campaign-guide skill grows significantly or if a more expensive model is used. The input cost scales roughly linearly with skill file size — doubling the skill doubles the per-scenario cost.
+
+## Consequences
+- **Correctness is tested end-to-end.** A scenario eval that passes confirms the full pipeline: skill checklist → file read → arithmetic → file write → correct value. A bounds check would have confirmed only the last property.
+- **Regressions are caught.** If the campaign-guide skill's post-turn checklist is edited in a way that breaks HP tracking, the eval fails before it reaches a live session.
+- **Fixtures are the source of truth for expected behaviour.** Adding a new scenario requires a fixture file and an assertion, not changes to production code.
+- **Slow by design.** Each eval makes real API calls. They are not run in CI on every commit — they are run before merging changes to the campaign-guide skill or bookkeeping pipeline.
+- **Constraint:** Do not mock the bookkeeping agent or the file system in these tests. The value comes from running the real agent against real files. Unit tests with mocks belong in `tests/` (not `tests/integration/`) and test parsing logic, not agent behaviour.

--- a/docs/adr/agent-harness/009-bookkeeping-silence-check.md
+++ b/docs/adr/agent-harness/009-bookkeeping-silence-check.md
@@ -1,0 +1,27 @@
+# ADR-009: Bookkeeping Silence Check
+
+## Status
+Rejected
+
+## Context
+The bookkeeping subagent's system prompt instructs it to "Work silently using tools only" and explicitly forbids narration. This is enforced by prompt, not by code — nothing currently detects or flags a bookkeeping agent that starts producing conversational text.
+
+A narrating bookkeeper is a latent failure mode. It indicates the agent is spending tokens on prose instead of tool use, is likely drifting from its checklist, and may be writing its reasoning to stdout rather than to the campaign files. It is also hard to notice in practice: the bookkeeping agent runs asynchronously after the DM response, its output is only visible in logs, and a short stray sentence won't obviously break anything while silently signalling a degraded agent.
+
+Detection cannot be retroactive — by the time text output is observed, the bookkeeping turn has already completed. The check is therefore a monitoring signal, not a gate.
+
+## Decision
+Not implemented.
+
+The implementation cost is near-zero — a string length check on messages already being processed, no extra API calls. But that makes the cost-benefit question moot: the real question is whether the check adds meaningful value, and it does not.
+
+The check is warning-only and post-hoc. By the time a warning fires, the bookkeeping turn has already completed. A narrating bookkeeper may have still updated all files correctly — in which case the warning is noise. If it narrated *and* missed an update, the scenario evals (ADR-008) catch that on the next run. The silence check adds no earlier or more actionable signal than the evals already provide.
+
+The 80-character threshold also introduces a concept that needs maintenance: future model versions may produce slightly more verbose tool confirmations that trip the threshold without indicating any real problem. Observability without a defined action to take when the signal fires adds noise, not value.
+
+The right response to a narrating bookkeeper is to run the eval suite and check whether correctness was affected — not to log a warning and move on.
+
+## Consequences
+- **No silence check added.** The bookkeeping pipeline stays simpler with no threshold constant to tune.
+- **Narration drift is covered indirectly.** If a narrating bookkeeper starts missing updates, the scenario evals (ADR-008) will catch the correctness failure.
+- **Constraint:** Do not add a post-hoc text-length check as a substitute for correctness testing. If bookkeeper narration becomes an observed problem in practice, the right response is a new scenario eval that asserts the specific update was made, not a style-level warning.

--- a/docs/adr/agent-harness/010-eval-regression-gate.md
+++ b/docs/adr/agent-harness/010-eval-regression-gate.md
@@ -1,0 +1,38 @@
+# ADR-010: Eval Regression Gate
+
+## Status
+Accepted
+
+## Context
+The scenario eval suite (ADR-008) exists but has no enforced trigger — it runs when someone remembers to run it. This makes it easy to skip when it matters most: immediately before merging a change to the campaign-guide skill or the bookkeeping pipeline.
+
+The evals are slow (~2–3 min) and cost real money (~$0.30 per run), so they should not run on every commit. But without a defined gate, "run before merging" remains informal and will be missed under time pressure.
+
+## Decision
+The eval suite is a **required gate** for two change categories:
+
+| Change category | Gate |
+|----------------|------|
+| Any edit to `.claude/skills/campaign-guide/` | Run eval suite before merging |
+| Any edit to `run_bookkeeping_subagent` or `get_bookkeeping_options` in `claude_agent.py` | Run eval suite before merging |
+
+All other changes (DM agent prompt, other skills, tooling, tests) do not require the gate.
+
+**Enforcement mechanism:** The ADR compliance reviewer hook (PostToolUse agent hook on Write/Edit in `.claude/settings.json`) reads all ADRs after every file modification. When a gated file is edited, the reviewer cites this ADR and its output surfaces as a `systemMessage` back to the Claude Code session that made the change. Claude Code is then responsible for running the eval suite and confirming all 4 scenarios pass before completing the task.
+
+This is a Claude Code gate, not a human one. The trigger is automatic (fires on every relevant Write/Edit) and the agent doing the work receives the prompt immediately in the same session.
+
+The gate is not automated in CI. The cost and latency of running LLM evals on every PR is not justified at this scale.
+
+**How to run:**
+```bash
+uv run pytest tests/integration/test_bookkeeping_evals.py -v
+```
+
+All 4 scenarios must pass. A single failure blocks the merge.
+
+## Consequences
+- **The gate is as strong as the ADR compliance reviewer.** It relies on the reviewer hook firing correctly and Claude Code acting on the `systemMessage`. This is the same mechanism that enforces all other ADR constraints in this codebase — if the reviewer is working, the gate is working.
+- **False negatives are possible.** A change to a skill file that does not affect bookkeeping will still trigger the gate. This is acceptable; a ~3 min run is a low cost for the confidence.
+- **Gate scope is narrow by design.** Requiring evals for every change would make them feel like a burden and encourage skipping. Scoping to the two change categories keeps the gate meaningful.
+- **Constraint:** Do not add the eval suite to a CI pipeline without also solving the API key management and cost attribution problems first. Do not widen the gate to cover all changes — this defeats the purpose of a targeted regression check.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+
 [tool.uv]
 package = true
 

--- a/tests/fixtures/campaign_guide_minimal.md
+++ b/tests/fixtures/campaign_guide_minimal.md
@@ -1,0 +1,21 @@
+# A Most Potent Brew - Campaign Guide
+
+> Minimal fixture campaign guide for bookkeeping evals
+
+---
+
+## Act 1: The Brewery Investigation
+
+**Story Goal**: Solve the giant rat problem in the brewery cellar
+
+### Beat 1.1: The Job Offer
+- **Accomplishment**: Party accepts the brewery extermination job
+- **Completion condition**: Players agree to take the job from Glowkindle
+
+### Beat 1.2: Into the Cellar
+- **Accomplishment**: Party enters brewery cellar and encounters the rat problem
+- **Completion condition**: Party descends into the cellar and engages the rats
+
+### Beat 1.3: Clearing the Cellar
+- **Accomplishment**: All rats defeated and cellar secured
+- **Completion condition**: All giant rats defeated

--- a/tests/fixtures/campaign_log_empty.md
+++ b/tests/fixtures/campaign_log_empty.md
@@ -1,0 +1,5 @@
+# Campaign Log
+
+*Session history will be recorded here.*
+
+---

--- a/tests/fixtures/sapphire_wizard.md
+++ b/tests/fixtures/sapphire_wizard.md
@@ -1,0 +1,93 @@
+# Sapphire Star - Level 1 Elf Wizard
+
+> Fixture character for bookkeeping evals — full spell slots: 1st level 0/2 used
+
+---
+
+## 📝 Basic Character Information
+
+| Field | Value |
+|-------|-------|
+| **Character Name** | Sapphire Star |
+| **Class & Level** | Wizard 1 |
+| **Race/Species** | High Elf |
+| **Background** | Sage |
+| **Alignment** | Neutral Good |
+| **Experience Points** | 0 / 300 |
+
+---
+
+## 🎯 Core Ability Scores
+
+| Ability | Score | Modifier | Saving Throw | Proficient? |
+|---------|-------|----------|--------------|-------------|
+| **Strength (STR)** | 8 | -1 | -1 | ❌ |
+| **Dexterity (DEX)** | 14 | +2 | +2 | ❌ |
+| **Constitution (CON)** | 13 | +1 | +1 | ❌ |
+| **Intelligence (INT)** | 16 | +3 | +5 | ⭕ |
+| **Wisdom (WIS)** | 12 | +1 | +3 | ⭕ |
+| **Charisma (CHA)** | 10 | +0 | +0 | ❌ |
+
+**Proficiency Bonus:** +2
+
+---
+
+## ⚔️ Combat Statistics
+
+| Stat | Value | Notes |
+|------|-------|-------|
+| **Armor Class (AC)** | 12 | No armor (10 + DEX) |
+| **Hit Points** | 7 / 7 | Hit Die: d6 |
+| **Hit Dice** | 1 / 1 | 1d6 |
+| **Speed** | 30 ft | Elf base speed |
+| **Initiative** | +2 | Dex modifier |
+
+---
+
+## 🔮 Spellcasting
+
+| Stat | Value |
+|------|-------|
+| **Spellcasting Ability** | Intelligence |
+| **Spell Save DC** | 13 |
+| **Spell Attack Bonus** | +5 |
+
+### Spell Slots
+| Level | Total | Used | Remaining |
+|-------|-------|------|-----------|
+| **Cantrips** | 3 | - | Unlimited |
+| **1st** | 2 | 0 | 2 |
+
+### Prepared Spells
+
+#### Cantrips (3)
+1. **Fire Bolt** - Ranged spell attack, 1d10 fire damage
+2. **Mage Hand** - Create spectral hand to manipulate objects
+3. **Prestidigitation** - Minor magical trick
+
+#### 1st Level Spells (Prepared: 4)
+1. **Mage Armor** - AC becomes 13 + DEX mod for 8 hours
+2. **Magic Missile** - 3 darts, 1d4+1 force damage each, auto-hit
+3. **Detect Magic** - Sense magic within 30 feet (ritual)
+4. **Shield** - Reaction, +5 AC until start of your next turn
+
+---
+
+## 🎒 Equipment & Inventory
+
+### Currency
+- **Gold Pieces (GP):** 10
+
+### Equipment
+- Quarterstaff
+- Component pouch
+- Scholar's pack
+- Spellbook
+
+---
+
+## ✨ Features & Traits
+
+### Class Features
+- **Spellcasting:** Can cast wizard spells from spellbook
+- **Arcane Recovery:** Once per day during short rest, recover spell slots totaling level ÷ 2 (rounded up)

--- a/tests/fixtures/thork_fighter.md
+++ b/tests/fixtures/thork_fighter.md
@@ -1,0 +1,74 @@
+# Thork Ironforge - Level 1 Dwarf Fighter
+
+> Fixture character for bookkeeping evals — starting HP: 10/12
+
+---
+
+## 📝 Basic Character Information
+
+| Field | Value |
+|-------|-------|
+| **Character Name** | Thork Ironforge |
+| **Class & Level** | Fighter 1 |
+| **Race/Species** | Mountain Dwarf |
+| **Background** | Soldier |
+| **Alignment** | Lawful Good |
+| **Experience Points** | 0 / 300 |
+
+---
+
+## 🎯 Core Ability Scores
+
+| Ability | Score | Modifier | Saving Throw | Proficient? |
+|---------|-------|----------|--------------|-------------|
+| **Strength (STR)** | 16 | +3 | +5 | ⭕ |
+| **Dexterity (DEX)** | 13 | +1 | +1 | ❌ |
+| **Constitution (CON)** | 15 | +2 | +4 | ⭕ |
+| **Intelligence (INT)** | 10 | +0 | +0 | ❌ |
+| **Wisdom (WIS)** | 12 | +1 | +1 | ❌ |
+| **Charisma (CHA)** | 8 | -1 | -1 | ❌ |
+
+**Proficiency Bonus:** +2
+
+---
+
+## ⚔️ Combat Statistics
+
+| Stat | Value | Notes |
+|------|-------|-------|
+| **Armor Class (AC)** | 18 | Chain mail + shield |
+| **Hit Points** | 10 / 12 | Hit Die: d10 |
+| **Hit Dice** | 1 / 1 | 1d10 |
+| **Speed** | 25 ft | Dwarf base speed |
+| **Initiative** | +1 | Dex modifier |
+
+---
+
+## ⚔️ Attacks & Weapons
+
+| Weapon | Attack Bonus | Damage | Type | Range | Notes |
+|--------|--------------|--------|------|-------|-------|
+| Warhammer | +5 | 1d8+3 | Bludgeoning | Melee | Versatile (1d10) |
+
+---
+
+## 🎒 Equipment & Inventory
+
+### Currency
+- **Gold Pieces (GP):** 10
+
+### Equipment
+- Chain mail armor
+- Shield
+- Warhammer
+
+### Consumables
+- **Minor Healing Potion** x1 (restores 2d4+2 HP)
+
+---
+
+## ✨ Features & Traits
+
+### Class Features
+- **Fighting Style (Defense):** +1 AC while wearing armor
+- **Second Wind:** Bonus action, regain 1d10+1 HP once per short/long rest ✅ AVAILABLE

--- a/tests/fixtures/thork_fighter_low_hp.md
+++ b/tests/fixtures/thork_fighter_low_hp.md
@@ -1,0 +1,74 @@
+# Thork Ironforge - Level 1 Dwarf Fighter
+
+> Fixture character for bookkeeping evals — starting HP: 5/12
+
+---
+
+## 📝 Basic Character Information
+
+| Field | Value |
+|-------|-------|
+| **Character Name** | Thork Ironforge |
+| **Class & Level** | Fighter 1 |
+| **Race/Species** | Mountain Dwarf |
+| **Background** | Soldier |
+| **Alignment** | Lawful Good |
+| **Experience Points** | 0 / 300 |
+
+---
+
+## 🎯 Core Ability Scores
+
+| Ability | Score | Modifier | Saving Throw | Proficient? |
+|---------|-------|----------|--------------|-------------|
+| **Strength (STR)** | 16 | +3 | +5 | ⭕ |
+| **Dexterity (DEX)** | 13 | +1 | +1 | ❌ |
+| **Constitution (CON)** | 15 | +2 | +4 | ⭕ |
+| **Intelligence (INT)** | 10 | +0 | +0 | ❌ |
+| **Wisdom (WIS)** | 12 | +1 | +1 | ❌ |
+| **Charisma (CHA)** | 8 | -1 | -1 | ❌ |
+
+**Proficiency Bonus:** +2
+
+---
+
+## ⚔️ Combat Statistics
+
+| Stat | Value | Notes |
+|------|-------|-------|
+| **Armor Class (AC)** | 18 | Chain mail + shield |
+| **Hit Points** | 5 / 12 | Hit Die: d10 |
+| **Hit Dice** | 1 / 1 | 1d10 |
+| **Speed** | 25 ft | Dwarf base speed |
+| **Initiative** | +1 | Dex modifier |
+
+---
+
+## ⚔️ Attacks & Weapons
+
+| Weapon | Attack Bonus | Damage | Type | Range | Notes |
+|--------|--------------|--------|------|-------|-------|
+| Warhammer | +5 | 1d8+3 | Bludgeoning | Melee | Versatile (1d10) |
+
+---
+
+## 🎒 Equipment & Inventory
+
+### Currency
+- **Gold Pieces (GP):** 10
+
+### Equipment
+- Chain mail armor
+- Shield
+- Warhammer
+
+### Consumables
+- **Minor Healing Potion** x1 (restores 2d4+2 HP)
+
+---
+
+## ✨ Features & Traits
+
+### Class Features
+- **Fighting Style (Defense):** +1 AC while wearing armor
+- **Second Wind:** Bonus action, regain 1d10+1 HP once per short/long rest ✅ AVAILABLE

--- a/tests/integration/test_bookkeeping_evals.py
+++ b/tests/integration/test_bookkeeping_evals.py
@@ -1,0 +1,202 @@
+"""Bookkeeping scenario eval suite.
+
+Exercises run_bookkeeping_subagent directly with fixture-based campaign state
+and synthetic DM exchanges, then asserts correct post-turn file values.
+
+Requires ANTHROPIC_API_KEY. Each test makes real API calls (~20-60s per scenario).
+Run before merging changes to the campaign-guide skill or bookkeeping pipeline:
+
+    uv run pytest tests/integration/test_bookkeeping_evals.py -v
+"""
+
+import re
+import shutil
+import uuid
+from pathlib import Path
+
+import pytest
+
+FIXTURES = Path(__file__).parent.parent / "fixtures"
+CAMPAIGNS = Path(__file__).parent.parent.parent / "campaigns"
+
+
+@pytest.fixture
+def campaign_dir():
+    """Create an isolated campaign directory from fixtures, yield (name, path), clean up after."""
+    name = f"eval_{uuid.uuid4().hex[:8]}"
+    path = CAMPAIGNS / name
+    (path / "characters").mkdir(parents=True)
+    yield name, path
+    if path.exists():
+        shutil.rmtree(path)
+
+
+def _make_progress(character_line: str, beat: str = "Beat 1.1: The Job Offer") -> str:
+    return (
+        f"# Eval Campaign Progress\n\n"
+        f"## Current Progress\n"
+        f"- **Act:** Act 1 - The Brewery Investigation\n"
+        f"- **Beat:** {beat} (In Progress)\n\n"
+        f"## Party\n"
+        f"{character_line}\n\n"
+        f"## Key Decisions\n"
+        f"- Accepted the brewery job\n"
+    )
+
+
+async def _drain(gen):
+    """Consume an async generator, discarding messages."""
+    async for _ in gen:
+        pass
+
+
+# =============================================================================
+# Scenario 1: HP damage
+# =============================================================================
+
+
+async def test_hp_damage(campaign_dir):
+    """3 damage to Thork (10/12 HP) → character file updated to 7/12."""
+    name, path = campaign_dir
+
+    shutil.copy(FIXTURES / "thork_fighter.md", path / "characters" / "thork.md")
+    shutil.copy(FIXTURES / "campaign_log_empty.md", path / "campaign_log.md")
+    (path / "campaign_progress.md").write_text(
+        _make_progress("- **Thork Ironforge** (Mountain Dwarf Fighter 1) - HP: 10/12")
+    )
+
+    from dnd_dm_agent.claude_agent import run_bookkeeping_subagent
+
+    await _drain(
+        run_bookkeeping_subagent(
+            user_msg="I swing my warhammer at the giant rat!",
+            dm_response=(
+                "Thork connects with his warhammer. The rat retaliates, biting into his arm "
+                "for 3 damage. Thork takes 3 damage and is now at 7 HP (7/12)."
+            ),
+            campaign=name,
+            character="thork",
+        )
+    )
+
+    content = (path / "characters" / "thork.md").read_text()
+    hp = re.search(r"\|\s*\*\*Hit Points\*\*\s*\|\s*(\d+)\s*/\s*(\d+)", content)
+    assert hp, "HP row not found in character file"
+    assert int(hp.group(1)) == 7, f"Expected current HP 7, got {hp.group(1)}"
+    assert int(hp.group(2)) == 12, f"Expected max HP 12, got {hp.group(2)}"
+
+
+# =============================================================================
+# Scenario 2: HP healing
+# =============================================================================
+
+
+async def test_hp_healing(campaign_dir):
+    """Healing potion (+4 HP) applied to Thork (5/12 HP) → character file updated to 9/12."""
+    name, path = campaign_dir
+
+    shutil.copy(FIXTURES / "thork_fighter_low_hp.md", path / "characters" / "thork.md")
+    shutil.copy(FIXTURES / "campaign_log_empty.md", path / "campaign_log.md")
+    (path / "campaign_progress.md").write_text(
+        _make_progress("- **Thork Ironforge** (Mountain Dwarf Fighter 1) - HP: 5/12")
+    )
+
+    from dnd_dm_agent.claude_agent import run_bookkeeping_subagent
+
+    await _drain(
+        run_bookkeeping_subagent(
+            user_msg="I drink my healing potion.",
+            dm_response=(
+                "Thork uncorks the minor healing potion and drinks it down. He regains 4 HP, "
+                "bringing him from 5 to 9 HP (9/12)."
+            ),
+            campaign=name,
+            character="thork",
+        )
+    )
+
+    content = (path / "characters" / "thork.md").read_text()
+    hp = re.search(r"\|\s*\*\*Hit Points\*\*\s*\|\s*(\d+)\s*/\s*(\d+)", content)
+    assert hp, "HP row not found in character file"
+    assert int(hp.group(1)) == 9, f"Expected current HP 9, got {hp.group(1)}"
+    assert int(hp.group(2)) == 12, f"Expected max HP 12, got {hp.group(2)}"
+
+
+# =============================================================================
+# Scenario 3: Spell slot use
+# =============================================================================
+
+
+async def test_spell_slot_use(campaign_dir):
+    """Sapphire casts Magic Missile (1st level) from full slots → used count increments to 1."""
+    name, path = campaign_dir
+
+    shutil.copy(FIXTURES / "sapphire_wizard.md", path / "characters" / "sapphire.md")
+    shutil.copy(FIXTURES / "campaign_log_empty.md", path / "campaign_log.md")
+    (path / "campaign_progress.md").write_text(
+        _make_progress("- **Sapphire Star** (High Elf Wizard 1) - HP: 7/7\n  - Spell Slots: 1st level 0/2 used")
+    )
+
+    from dnd_dm_agent.claude_agent import run_bookkeeping_subagent
+
+    await _drain(
+        run_bookkeeping_subagent(
+            user_msg="I cast Magic Missile at the rat!",
+            dm_response=(
+                "Sapphire expends a 1st-level spell slot to cast Magic Missile. Three glowing darts "
+                "streak toward the rat. Sapphire has 1 first-level spell slot remaining (used 1 of 2)."
+            ),
+            campaign=name,
+            character="sapphire",
+        )
+    )
+
+    content = (path / "characters" / "sapphire.md").read_text()
+    # Match the spell slot table row: | **1st** | 2 | 0 | 2 |
+    slot = re.search(r"\*\*1st\*\*\s*\|\s*(\d+)\s*\|\s*(\d+)\s*\|\s*(\d+)", content)
+    assert slot, "1st-level spell slot row not found in character file"
+    total, used, remaining = int(slot.group(1)), int(slot.group(2)), int(slot.group(3))
+    assert total == 2, f"Expected total slots 2, got {total}"
+    assert used == 1, f"Expected used slots 1 after casting, got {used}"
+    assert remaining == 1, f"Expected remaining slots 1, got {remaining}"
+
+
+# =============================================================================
+# Scenario 4: Beat advancement
+# =============================================================================
+
+
+async def test_beat_advancement(campaign_dir):
+    """Completing Beat 1.1 (accept the job) → campaign_progress.md advances to Beat 1.2."""
+    name, path = campaign_dir
+
+    shutil.copy(FIXTURES / "thork_fighter.md", path / "characters" / "thork.md")
+    shutil.copy(FIXTURES / "campaign_log_empty.md", path / "campaign_log.md")
+    shutil.copy(FIXTURES / "campaign_guide_minimal.md", path / "campaign_guide.md")
+    (path / "campaign_progress.md").write_text(
+        _make_progress(
+            "- **Thork Ironforge** (Mountain Dwarf Fighter 1) - HP: 10/12",
+            beat="Beat 1.1: The Job Offer",
+        )
+    )
+
+    from dnd_dm_agent.claude_agent import run_bookkeeping_subagent
+
+    await _drain(
+        run_bookkeeping_subagent(
+            user_msg="Fine, we'll take the job. How much does it pay?",
+            dm_response=(
+                "Glowkindle grins with relief. 'Fifty gold pieces if you clear out every last rat and "
+                "find where they came from.' Thork agrees. Beat 1.1 is now complete — the party has "
+                "accepted the job and will proceed to Beat 1.2: Into the Cellar."
+            ),
+            campaign=name,
+            character="thork",
+        )
+    )
+
+    progress = (path / "campaign_progress.md").read_text()
+    assert "Beat 1.1" not in progress or "Beat 1.2" in progress, (
+        "Expected campaign_progress.md to advance beyond Beat 1.1"
+    )
+    assert "Beat 1.2" in progress, f"Expected Beat 1.2 in progress file, got:\n{progress}"


### PR DESCRIPTION
## Summary

- **Scenario eval suite** (ADR-008): 4 fixture-based integration tests exercising `run_bookkeeping_subagent` directly — HP damage, healing, spell slot use, and beat advancement. Each test creates an isolated campaign dir, runs the real bookkeeping agent, asserts correct file state, and cleans up.
- **ADR decisions** (007–010): documents what was considered and why two items were rejected (data integrity validator, silence check) — the decision log is as important as what was built.
- **Eval regression gate** (ADR-010): enforced via the existing ADR compliance reviewer hook, which now checks for required follow-up actions in addition to constraint violations. Fires when `campaign-guide` skill or bookkeeping pipeline is edited.
- **`asyncio_mode = auto`** added to `pyproject.toml`; `@pytest.mark.asyncio` decorators removed from new tests.

## Test Plan

- [x] Unit tests pass: `uv run pytest tests/ --ignore=tests/integration -q`
- [ ] Integration evals pass (requires `ANTHROPIC_API_KEY`, ~2–3 min): `uv run pytest tests/integration/test_bookkeeping_evals.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)